### PR TITLE
fix: correct ThumbnailProcessor repository, remove archived project

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ Awesome Shopware 6 plugins, resources, themes, etc
 - [Shopware 6 Toolbox](https://plugins.jetbrains.com/plugin/17632-shopware-6-toolbox)
 
 ### Speed Optimizations
-- [Frosh ThumbnailProcessor](https://github.com/FriendsOfShopware/FroshThumbnailProcessor)
-- [Frosh WebP Images for Shopware 6](https://github.com/FriendsOfShopware/FroshPlatformWebP)
+- [Frosh ThumbnailProcessor](https://github.com/FriendsOfShopware/FroshPlatformThumbnailProcessor)
 - [Image optimizer](https://github.com/runelaenen/sw6-media-optimizer)
 
 ### DevOps


### PR DESCRIPTION
- the url to the thumbnailProcessor repo is for sw5
- FroshPlatformWebP has been archived